### PR TITLE
fix(client): primary buttons use host primary-fill/foreground tokens

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -34,7 +34,7 @@ window.__ModuleLoader__.load({
         ".dsh-update-btn{background:var(--dsw-alias-bg-layer-2,#374151);color:var(--dsw-alias-label-primary,#f3f4f6);border:1px solid var(--dsw-alias-border-l1,#4b5563);border-radius:6px;padding:3px 10px;font-size:12px;cursor:pointer;}" +
         ".dsh-update-btn:hover{border-color:var(--dsw-alias-brand-primary,#4f8cff);}" +
         ".dsh-update-btn:disabled{opacity:.5;cursor:default;}" +
-        ".dsh-update-btn-primary{background:var(--dsw-alias-brand-primary,#4f8cff);border-color:var(--dsw-alias-brand-primary,#4f8cff);color:#fff;font-weight:600;}" +
+        ".dsh-update-btn-primary{background:var(--dsw-alias-button-primary-fill,var(--dsw-alias-brand-primary,#4f8cff));border-color:var(--dsw-alias-button-primary-fill,var(--dsw-alias-brand-primary,#4f8cff));color:var(--dsw-alias-label-primary-foreground,#fff);font-weight:600;}" +
         ".dsh-update-status{color:var(--dsw-alias-label-secondary,#9ca3af);font-size:12px;}" +
         ".dsh-plugin-banner{position:fixed;top:64px;left:50%;transform:translateX(-50%);z-index:9998;pointer-events:auto;max-width:min(560px,calc(100vw - 32px));background:var(--dsw-alias-bg-overlay,#1f2937);color:var(--dsw-alias-label-primary,#f3f4f6);border:1px solid var(--dsw-alias-border-l2,#374151);border-radius:10px;padding:12px 16px;box-shadow:0 8px 24px rgba(0,0,0,.35);font-size:13px;line-height:1.5;}" +
         ".dsh-plugin-body{min-width:0;}" +
@@ -49,7 +49,7 @@ window.__ModuleLoader__.load({
         ".dsh-plugin-btn{background:var(--dsw-alias-bg-layer-2,#374151);color:var(--dsw-alias-label-primary,#f3f4f6);border:1px solid var(--dsw-alias-border-l1,#4b5563);border-radius:6px;padding:3px 10px;font-size:12px;cursor:pointer;}" +
         ".dsh-plugin-btn:hover{border-color:var(--dsw-alias-brand-primary,#4f8cff);}" +
         ".dsh-plugin-btn:disabled{opacity:.5;cursor:default;}" +
-        ".dsh-plugin-btn-primary{background:var(--dsw-alias-brand-primary,#4f8cff);border-color:var(--dsw-alias-brand-primary,#4f8cff);color:#fff;font-weight:600;}" +
+        ".dsh-plugin-btn-primary{background:var(--dsw-alias-button-primary-fill,var(--dsw-alias-brand-primary,#4f8cff));border-color:var(--dsw-alias-button-primary-fill,var(--dsw-alias-brand-primary,#4f8cff));color:var(--dsw-alias-label-primary-foreground,#fff);font-weight:600;}" +
         ".dsh-plugin-ok{color:#34d399;}" +
         ".dsh-plugin-fail{color:#f87171;}" +
         ".dsh-plugin-warn{color:#fbbf24;}" +


### PR DESCRIPTION
修复深色主题下插件横幅主按钮文字不可见（白底白字）的问题。

根因：`--dsw-alias-brand-primary` 随主题反转——浅色下解析为近黑色 `#0f1115`，深色下为近白色 `#f9fafb`。原 CSS 用它做按钮底色并硬编码 `color:#fff`，浅色正常（黑底白字），深色变成白底白字，标签完全不可见。

修复：改用宿主 Button 组件同款 token：
- 底色/边框：`--dsw-alias-button-primary-fill`（回退 `brand-primary`）
- 文字色：`--dsw-alias-label-primary-foreground`（回退 `#fff`）

浅色模式渲染结果完全不变；深色模式为白底深字（#f9fafb / #0f1115，对比度 18:1），与 DSH 原生主按钮一致。

#11 