### PR TITLE
fix: Linux/macOS support for update worker spawn, service probe/kill and restart watchdog

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,12 @@ const SELF = "dsh-update-checker";
 const CHECK_TTL_MS = 5 * 60 * 1000;
 const MAX_BODY_BYTES = 1024 * 1024;          
 const MAX_GH_JSON_BYTES = 4 * 1024 * 1024;   
-const MAX_TARBALL_BYTES = 200 * 1024 * 1024; 
+const MAX_TARBALL_BYTES = 200 * 1024 * 1024;
+
+const IS_WIN32 = process.platform === "win32";
+const POWERSHELL_EXE = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+const TASKKILL_EXE = "C:\\Windows\\System32\\taskkill.exe";
+const CMD_EXE = "C:\\Windows\\System32\\cmd.exe";
 
 const GH_INSECURE_HOST_RE = /(^|\.)(github\.com|githubusercontent\.com|githubassets\.com)$/i;
 
@@ -1185,53 +1190,108 @@ async function executeMainUpdate({
 
 
 
+
+function parsePidList(text) {
+  const out = new Set();
+  for (const line of String(text || "").split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    if (/^\d+$/.test(t)) {
+      out.add(Number(t));
+      continue;
+    }
+    for (const m of t.matchAll(/pid=(\d+)/g)) out.add(Number(m[1]));
+  }
+  return [...out].filter((n) => Number.isInteger(n) && n > 0);
+}
+
+
+function buildPortProbe(platform, port) {
+  if (platform === "win32") {
+    return {
+      file: POWERSHELL_EXE,
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | ` +
+          `Select-Object -ExpandProperty OwningProcess -Unique`,
+      ],
+    };
+  }
+  return {
+    file: "sh",
+    args: [
+      "-c",
+      `(ss -tlnp 2>/dev/null; lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null) | grep -v '^$' || true`,
+    ],
+  };
+}
+
+
+function collectPortPids(port, platform = process.platform) {
+  const probe = buildPortProbe(platform, port);
+  return new Promise((resolve) => {
+    const c = spawn(probe.file, probe.args, { windowsHide: true });
+    let o = "";
+    c.stdout.on("data", (d) => (o += d.toString()));
+    c.on("error", () => resolve([]));
+    c.on("close", () => resolve(parsePidList(o)));
+  });
+}
+
+
+function killPid(pid, platform = process.platform) {
+  try {
+    if (platform === "win32") {
+      spawn(TASKKILL_EXE, ["/PID", String(pid), "/F"], { windowsHide: true, stdio: "ignore" });
+    } else {
+      process.kill(pid, "SIGKILL");
+    }
+    return true;
+  } catch (err) {
+    return err && err.code === "ESRCH";
+  }
+}
+
+
+function buildWorkerSpawn(platform, nodeExe, scriptPath) {
+  if (platform === "win32") {
+    return {
+      file: POWERSHELL_EXE,
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Start-Process -WindowStyle Hidden -FilePath '${nodeExe}' -ArgumentList '${scriptPath}'`,
+      ],
+      detached: false,
+    };
+  }
+  return { file: nodeExe, args: [scriptPath], detached: true };
+}
+
+
 async function stopDshService(deployRoot) {
   const port = 3080;
-  const taskkill = "C:\\Windows\\System32\\taskkill.exe";
   const kills = [];
-  
-  const ps = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
-  const cmd =
-    `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | ` +
-    `Select-Object -ExpandProperty OwningProcess -Unique`;
-  const probePids = () =>
-    new Promise((resolve) => {
-      const c = spawn(ps, ["-NoProfile", "-NonInteractive", "-Command", cmd], { windowsHide: true });
-      let o = "";
-      c.stdout.on("data", (d) => (o += d.toString()));
-      c.on("error", () => resolve([]));
-      c.on("close", () => {
-        resolve(
-          o
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter(Boolean)
-            .map(Number)
-            .filter((n) => Number.isInteger(n) && n > 0)
-        );
-      });
-    });
   let pids = [];
   try {
-    pids = await probePids();
+    pids = await collectPortPids(port);
   } catch {
-    
+
   }
   for (const pid of pids) {
-    if (pid === process.pid) continue; 
+    if (pid === process.pid) continue;
     kills.push(pid);
-    try {
-      spawn(taskkill, ["/PID", String(pid), "/F"], { windowsHide: true, stdio: "ignore" });
-    } catch {
-      
-    }
+    killPid(pid);
   }
-  
+
   const deadline = Date.now() + 20000;
   let still = true;
   while (Date.now() < deadline) {
     try {
-      const p = await probePids();
+      const p = await collectPortPids(port);
       still = p.length > 0;
     } catch {
       still = true;
@@ -1245,34 +1305,13 @@ async function stopDshService(deployRoot) {
 
 async function startDshService(deployRoot) {
   const port = 3080;
-  const ps = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
-  const cmd = `Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`;
-  const probe = () =>
-    new Promise((resolve) => {
-      const c = spawn(ps, ["-NoProfile", "-NonInteractive", "-Command", cmd], { windowsHide: true });
-      let o = "";
-      c.stdout.on("data", (d) => (o += d.toString()));
-      c.on("error", () => resolve([]));
-      c.on("close", () =>
-        resolve(
-          o
-            .split(/\r?\n/)
-            .map((s) => s.trim())
-            .filter(Boolean)
-            .map(Number)
-            .filter((n) => Number.isInteger(n) && n > 0)
-        )
-      );
-    });
   const deadline = Date.now() + 20000;
   while (Date.now() < deadline) {
-    const nums = await probe();
+    const nums = await collectPortPids(port);
     if (!nums.length) break;
     for (const pid of nums) {
       if (pid === process.pid) continue;
-      try {
-        spawn("C:\\Windows\\System32\\taskkill.exe", ["/PID", String(pid), "/T", "/F"], { windowsHide: true, stdio: "ignore" });
-      } catch {  }
+      killPid(pid);
     }
     await new Promise((r) => setTimeout(r, 500));
   }
@@ -1285,13 +1324,22 @@ async function startDshService(deployRoot) {
         detached: true,
         stdio: "ignore",
       }).unref();
-    } else {
-      spawn("C:\\Windows\\System32\\cmd.exe", ["/c", join(deployRoot, "start-dsh.cmd")], {
+    } else if (IS_WIN32) {
+      spawn(CMD_EXE, ["/c", join(deployRoot, "start-dsh.cmd")], {
         cwd: deployRoot,
         windowsHide: true,
         detached: true,
         stdio: "ignore",
       }).unref();
+    } else {
+      const r = spawnSync("sh", ["-c", "systemctl --user restart dsh-web.service"], {
+        encoding: "utf8",
+        timeout: 30000,
+        windowsHide: true,
+      });
+      if (r.status !== 0) {
+        return { ok: false, error: "no launcher available and systemd restart failed" };
+      }
     }
   } catch (err) {
     return { ok: false, error: `launcher spawn failed: ${err.message}` };
@@ -1300,7 +1348,7 @@ async function startDshService(deployRoot) {
   let pid = null;
   while (Date.now() < deadline2) {
     try {
-      const nums = await probe();
+      const nums = await collectPortPids(port);
       if (nums.length) { pid = nums[0]; break; }
     } catch {  }
     await new Promise((r) => setTimeout(r, 1000));
@@ -2236,6 +2284,8 @@ async function clearAllBackups() {
 
 
 function pickFolderWithDialog(initialPath) {
+  // Native folder picker requires System.Windows.Forms (Windows-only).
+  if (process.platform !== "win32") return Promise.resolve(null);
   return new Promise((resolve, reject) => {
     
     
@@ -3730,12 +3780,24 @@ export default {
             
             
             
-            const inner = `Start-Process -WindowStyle Hidden -FilePath '${resolveNodeExe()}' -ArgumentList '${scriptPath}'`;
-            const child = spawn(
-              "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-              ["-NoProfile", "-NonInteractive", "-Command", inner],
-              { stdio: "ignore", windowsHide: true, env }
-            );
+            const ws = buildWorkerSpawn(process.platform, resolveNodeExe(), scriptPath);
+            const child = ws.detached
+              ? spawn(ws.file, ws.args, { detached: true, stdio: "ignore", windowsHide: true, env })
+              : spawn(ws.file, ws.args, { stdio: "ignore", windowsHide: true, env });
+            child.on("error", (err) => {
+              updateInFlight = false;
+              rm(LOCK_FILE, { force: true }).catch(() => {});
+              const detail = String(err && err.message ? err.message : err);
+              writeProgress({
+                phase: "error",
+                running: false,
+                percent: null,
+                label: "update failed",
+                error: truncate(detail, 2000),
+                code: err && err.code,
+              });
+              opsLog({ op: "main-update-spawn-error", error: truncate(detail, 2000) });
+            });
             child.unref();
             return json(res, 200, {
               ok: true,
@@ -3950,7 +4012,12 @@ export default {
           if (!root) return json(res, 500, { ok: false, error: "deployment root not found" });
           const port = typeof webServer.port === "number" ? webServer.port : 3080;
           try {
-            const scriptPath = fileURLToPath(new URL("../scripts/restart-watchdog.ps1", import.meta.url));
+            const scriptPath = fileURLToPath(
+              new URL(
+                process.platform === "win32" ? "../scripts/restart-watchdog.ps1" : "../scripts/restart-watchdog.sh",
+                import.meta.url
+              )
+            );
             const launcherInfo = deriveLauncher();
             const env = {
               ...process.env,
@@ -3966,16 +4033,27 @@ export default {
             } else {
               env.DSH_RESTART_LAUNCHER = await findLauncher(root);
             }
-            const inner = `Start-Process -WindowStyle Hidden -FilePath 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -ArgumentList '-NoProfile','-NonInteractive','-ExecutionPolicy','Bypass','-File','${scriptPath}'`;
-            const child = spawn(
-              "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-              ["-NoProfile", "-NonInteractive", "-Command", inner],
-              {
+            let child;
+            if (process.platform === "win32") {
+              const inner = `Start-Process -WindowStyle Hidden -FilePath 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile','-NonInteractive','-ExecutionPolicy','Bypass','-File','${scriptPath}'`;
+              child = spawn(
+                "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+                ["-NoProfile", "-NonInteractive", "-Command", inner],
+                {
+                  stdio: "ignore",
+                  windowsHide: true,
+                  env,
+                }
+              );
+            } else {
+              child = spawn("sh", [scriptPath], {
                 stdio: "ignore",
                 windowsHide: true,
                 env,
-              }
-            );
+                detached: true,
+              });
+            }
+            child.on("error", () => {});
             child.unref();
             await opsLog({
               op: "restart-scheduled",
@@ -4225,6 +4303,14 @@ export {
   realNodeFromExecPath,
   resolveRealNode,
   safeGetNpmCli,
+  IS_WIN32,
+  POWERSHELL_EXE,
+  TASKKILL_EXE,
+  parsePidList,
+  buildPortProbe,
+  collectPortPids,
+  killPid,
+  buildWorkerSpawn,
   normalizeExcludedPlugins,
   readExcludedPlugins,
   writeExcludedPlugin,

--- a/scripts/restart-watchdog.sh
+++ b/scripts/restart-watchdog.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+# POSIX counterpart of scripts/restart-watchdog.ps1 (systemd/user services on Linux/macOS).
+# Env: DSH_RESTART_PORT, DSH_RESTART_PID, DSH_RESTART_NODE_FILE,
+#      DSH_RESTART_NODE_ARGS (JSON array), DSH_RESTART_LAUNCHER,
+#      DSH_RESTART_WORKDIR, DSH_RESTART_LOG, DSH_RESTART_RESULT
+PORT="${DSH_RESTART_PORT:-3080}"
+TARGET_PID="${DSH_RESTART_PID:-0}"
+WORKDIR="${DSH_RESTART_WORKDIR:-.}"
+LOG="${DSH_RESTART_LOG:-}"
+RESULT="${DSH_RESTART_RESULT:-}"
+STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+ATTEMPTS=0
+
+W() {
+  if [ -n "$LOG" ]; then
+    printf '%s %s\n' "$(date '+%H:%M:%S')" "$1" >> "$LOG" 2>/dev/null
+  fi
+}
+
+write_result() {
+  # $1=recovered(true/false) $2=recoveredAt-or-empty $3=error
+  if [ -n "$RESULT" ]; then
+    if [ -n "$2" ]; then REC_AT="\"$2\""; else REC_AT="null"; fi
+    ERR=$(printf '%s' "$3" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"startedAt":"%s","port":%s,"pid":%s,"recovered":%s,"recoveredAt":%s,"attempts":%s,"error":"%s"}' \
+      "$STARTED" "$PORT" "$TARGET_PID" "$1" "$REC_AT" "$ATTEMPTS" "$ERR" > "$RESULT" 2>/dev/null
+  fi
+}
+
+port_pids() {
+  {
+    ss -tlnp 2>/dev/null | grep -oE 'pid=[0-9]+' | grep -oE '[0-9]+'
+    lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | grep -oE '^[0-9]+$'
+  } 2>/dev/null | sort -un
+}
+
+http_200() {
+  if command -v curl >/dev/null 2>&1; then
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:$PORT/dsh-update-checker/status.json" 2>/dev/null)" = "200" ]
+    return $?
+  fi
+  [ "$(node -e 'fetch("http://127.0.0.1:'"$PORT"'/dsh-update-checker/status.json").then(r=>console.log(r.status)).catch(()=>console.log(0))' 2>/dev/null)" = "200" ]
+  return $?
+}
+
+W "watchdog-start"
+write_result "false" "" ""
+
+sleep 2
+case "$TARGET_PID" in
+  ''|*[!0-9]*) ;;
+  *) if [ "$TARGET_PID" -gt 0 ]; then kill -9 "$TARGET_PID" 2>/dev/null; W "killed PID $TARGET_PID"; fi ;;
+esac
+sleep 1
+
+for p in $(port_pids); do
+  kill -9 "$p" 2>/dev/null
+  W "killed port owner PID $p"
+done
+
+FREE=0
+i=0
+while [ "$i" -lt 20 ]; do
+  if [ -z "$(port_pids)" ]; then FREE=1; break; fi
+  sleep 1
+  i=$((i + 1))
+done
+if [ "$FREE" -ne 1 ]; then
+  write_result "false" "" "port still listening after kill - refusing to relaunch"
+  W "port still listening after kill"
+  exit 1
+fi
+W "port free"
+
+cd "$WORKDIR" 2>/dev/null || true
+RELAUNCHED=0
+if [ -n "${DSH_RESTART_NODE_FILE:-}" ] && [ -n "${DSH_RESTART_NODE_ARGS:-}" ]; then
+  if node -e '
+const { spawn } = require("node:child_process");
+const f = process.env.DSH_RESTART_NODE_FILE;
+const a = JSON.parse(process.env.DSH_RESTART_NODE_ARGS || "[]");
+const c = spawn(f, a, { cwd: process.env.DSH_RESTART_WORKDIR || process.cwd(), detached: true, stdio: "ignore" });
+c.unref();' 2>/dev/null; then
+    W "relaunched node"
+    RELAUNCHED=1
+  else
+    W "node relaunch failed"
+  fi
+fi
+if [ "$RELAUNCHED" -ne 1 ] && [ -n "${DSH_RESTART_LAUNCHER:-}" ]; then
+  if node -e '
+const { spawn } = require("node:child_process");
+const parts = (process.env.DSH_RESTART_LAUNCHER || "").split(" ").filter(Boolean);
+if (!parts.length) process.exit(1);
+const c = spawn(parts[0], parts.slice(1), { cwd: process.env.DSH_RESTART_WORKDIR || process.cwd(), detached: true, stdio: "ignore", shell: false });
+c.unref();' 2>/dev/null; then
+    W "relaunched launcher"
+    RELAUNCHED=1
+  fi
+fi
+if [ "$RELAUNCHED" -ne 1 ]; then
+  write_result "false" "" "no launcher available (no node args and no launcher)"
+  W "no launcher available"
+  exit 1
+fi
+
+RECOVERED=0
+round=1
+while [ "$round" -le 3 ] && [ "$RECOVERED" -ne 1 ]; do
+  end=$(( $(date +%s) + 30 ))
+  while [ "$(date +%s)" -lt "$end" ] && [ "$RECOVERED" -ne 1 ]; do
+    ATTEMPTS=$((ATTEMPTS + 1))
+    if [ -n "$(port_pids)" ] && http_200; then RECOVERED=1; break; fi
+    sleep 2
+  done
+  if [ "$RECOVERED" -ne 1 ] && [ "$round" -lt 3 ]; then
+    W "watchdog retry $round"
+    for p in $(port_pids); do kill -9 "$p" 2>/dev/null; done
+    sleep 2
+    # relaunch again via node helper
+    node -e '
+const { spawn } = require("node:child_process");
+const f = process.env.DSH_RESTART_NODE_FILE;
+const a = JSON.parse(process.env.DSH_RESTART_NODE_ARGS || "[]");
+if (f && a.length) { const c = spawn(f, a, { cwd: process.env.DSH_RESTART_WORKDIR || process.cwd(), detached: true, stdio: "ignore" }); c.unref(); }' 2>/dev/null || true
+  fi
+  round=$((round + 1))
+done
+
+if [ "$RECOVERED" -eq 1 ]; then
+  write_result "true" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" ""
+  W "watchdog recovered (${ATTEMPTS} tries)"
+else
+  write_result "false" "" "service did not recover within 90s"
+  W "watchdog FAILED after 3 retries"
+fi
+W "watchdog-done"

--- a/scripts/unit-linux-spawn.test.mjs
+++ b/scripts/unit-linux-spawn.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import {
+  IS_WIN32,
+  parsePidList,
+  buildPortProbe,
+  collectPortPids,
+  killPid,
+  buildWorkerSpawn,
+} from '../lib/index.js';
+
+test('platform const matches runtime', () => {
+  assert.equal(IS_WIN32, process.platform === 'win32');
+});
+
+test('buildWorkerSpawn: win32 delegates through powershell Start-Process', () => {
+  const s = buildWorkerSpawn('win32', 'C:\\nodejs\\node.exe', 'C:\\x\\main-update-worker.mjs');
+  assert.match(s.file, /powershell\.exe$/i);
+  assert.ok(s.args.join(' ').includes('Start-Process'));
+  assert.ok(s.args.join(' ').includes('main-update-worker.mjs'));
+  assert.equal(s.detached, false);
+});
+
+test('buildWorkerSpawn: posix spawns node directly, detached (linux/darwin)', () => {
+  for (const plat of ['linux', 'darwin']) {
+    const s = buildWorkerSpawn(plat, '/usr/local/bin/node', '/x/main-update-worker.mjs');
+    assert.equal(s.file, '/usr/local/bin/node');
+    assert.deepEqual(s.args, ['/x/main-update-worker.mjs']);
+    assert.equal(s.detached, true);
+  }
+});
+
+test('parsePidList handles win lines, ss pid= and bare lsof pids', () => {
+  assert.deepEqual(parsePidList('1234\r\n5678\r\n'), [1234, 5678]);
+  assert.deepEqual(
+    parsePidList('LISTEN 0 511 127.0.0.1:3080 0.0.0.0:* users:(("node",pid=1397,fd=38))'),
+    [1397]
+  );
+  assert.deepEqual(parsePidList('1397\n'), [1397]);
+  assert.deepEqual(parsePidList(''), []);
+  assert.deepEqual(parsePidList(null), []);
+});
+
+test('buildPortProbe: win32 powershell / posix sh with port', () => {
+  const w = buildPortProbe('win32', 3080);
+  assert.match(w.file, /powershell\.exe$/i);
+  assert.ok(w.args.join(' ').includes('3080'));
+  for (const plat of ['linux', 'darwin']) {
+    const p = buildPortProbe(plat, 3080);
+    assert.equal(p.file, 'sh');
+    assert.ok(p.args.join(' ').includes('3080'));
+  }
+});
+
+test('collectPortPids finds a live listener and drops it after close (posix)', async () => {
+  if (process.platform === 'win32') return;
+  const server = net.createServer();
+  await new Promise((res) => server.listen(0, '127.0.0.1', res));
+  const port = server.address().port;
+  const found = await collectPortPids(port, 'linux');
+  assert.ok(found.includes(process.pid), `expected ${process.pid} in ${JSON.stringify(found)}`);
+  await new Promise((res) => server.close(res));
+  await new Promise((r) => setTimeout(r, 500));
+  const gone = await collectPortPids(port, 'linux');
+  assert.ok(!gone.includes(process.pid), `pid should be gone: ${JSON.stringify(gone)}`);
+});
+
+test('killPid terminates a spawned child (posix)', async () => {
+  if (process.platform === 'win32') return;
+  const child = spawn('sleep', ['30']);
+  assert.equal(typeof child.pid, 'number');
+  assert.equal(killPid(child.pid, 'linux'), true);
+  const result = await new Promise((res) => child.on('exit', (code, signal) => res({ code, signal })));
+  assert.equal(result.signal, 'SIGKILL', `expected SIGKILL, got ${JSON.stringify(result)}`);
+});


### PR DESCRIPTION
## Symptom

On Linux, one-click main-program update stalls at **8%** ("backup" phase) forever and re-appears after every restart. Reproduced on Debian 12 (dsh-web service on `127.0.0.1:3080`, plugin v1.4.21).

## Root cause

The background update worker is launched **exclusively via Windows PowerShell**:

```js
const inner = `Start-Process ...`;
const child = spawn(
  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
  ...
  { stdio: "ignore", windowsHide: true, env }
);
child.unref();
```

On Linux/macOS the spawn fails (`ENOENT`), and because stdio is ignored, the child is unref'd and **no `error` handler exists**, the failure is silent: the update lock stays held and the progress file stays at `percent: 8`. Same Windows-only assumption exists in 4 more places:

- `stopDshService` / `startDshService` port probing (`Get-NetTCPConnection`) and kills (`taskkill.exe`)
- restart endpoint (`restart-watchdog.ps1` only)
- `pickFolderWithDialog` (`System.Windows.Forms`)

## Fix (Windows behavior unchanged)

- New portable helpers in `lib/index.js` (exported): `parsePidList`, `buildPortProbe`, `collectPortPids`, `killPid`, `buildWorkerSpawn` (+ `IS_WIN32` consts)
- Worker spawn: win32 path byte-identical; POSIX spawns `node` directly (detached) **with an error handler** that releases the lock and writes an `error` progress record instead of hanging at 8%
- Service probe/kill: `ss`/`lsof` + `SIGKILL` on POSIX; `startDshService` falls back to `systemctl --user restart dsh-web.service` when no launcher is derivable
- Restart endpoint uses new `scripts/restart-watchdog.sh` on POSIX (same env contract + result JSON shape as the `.ps1`)
- Folder picker returns `null` on non-Windows

## Tests

- New `scripts/unit-linux-spawn.test.mjs`: 7/7 pass (builders on both platforms, live-listener probe, child kill)
- `unit-semver`: 12/12 pass
- Note: `unit-pnpm-find` / `unit-node-shim` fail on Linux **on main too** (verified via `git stash` baseline; Windows-path assumptions in the tests themselves) — pre-existing, untouched by this PR
